### PR TITLE
DbContext with passed DbConnection

### DIFF
--- a/Orleans.StorageProviders.SimpleSQLServerStorage.sln
+++ b/Orleans.StorageProviders.SimpleSQLServerStorage.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Orleans.StorageProviders.SimpleSQLServerStorage", "Orleans.StorageProviders.SimpleSQLServerStorage\Orleans.StorageProviders.SimpleSQLServerStorage.csproj", "{EC70A034-22ED-4CF8-AB4B-7F89E5395268}"
 EndProject
@@ -12,6 +12,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SimpleGrainInterfaces", "tests\SimpleGrainInterfaces\SimpleGrainInterfaces.csproj", "{3FF17408-E556-43F5-AF82-5881DC1551A0}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SimpleSQLServerStorage.Tests", "Tests\SimpleSQLServerStorage.Tests\SimpleSQLServerStorage.Tests.csproj", "{9266AAB3-B064-4A0D-B7C6-6101EB2226C8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestHost", "TestHost\TestHost.csproj", "{34CFDDFC-D674-479B-9046-3E3776F15BB1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -35,6 +37,10 @@ Global
 		{9266AAB3-B064-4A0D-B7C6-6101EB2226C8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9266AAB3-B064-4A0D-B7C6-6101EB2226C8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9266AAB3-B064-4A0D-B7C6-6101EB2226C8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{34CFDDFC-D674-479B-9046-3E3776F15BB1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{34CFDDFC-D674-479B-9046-3E3776F15BB1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{34CFDDFC-D674-479B-9046-3E3776F15BB1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{34CFDDFC-D674-479B-9046-3E3776F15BB1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -43,5 +49,6 @@ Global
 		{563672AB-EA40-49D8-BEBC-E0152D98615E} = {55B9368A-50BE-4318-B181-70FBD67A1D73}
 		{3FF17408-E556-43F5-AF82-5881DC1551A0} = {55B9368A-50BE-4318-B181-70FBD67A1D73}
 		{9266AAB3-B064-4A0D-B7C6-6101EB2226C8} = {55B9368A-50BE-4318-B181-70FBD67A1D73}
+		{34CFDDFC-D674-479B-9046-3E3776F15BB1} = {55B9368A-50BE-4318-B181-70FBD67A1D73}
 	EndGlobalSection
 EndGlobal

--- a/Orleans.StorageProviders.SimpleSQLServerStorage/KeyValueDbConfiguration.cs
+++ b/Orleans.StorageProviders.SimpleSQLServerStorage/KeyValueDbConfiguration.cs
@@ -1,18 +1,21 @@
-﻿using System.Data.Entity;
+﻿using System;
+using System.Data.Entity;
 using System.Data.Entity.Infrastructure;
 using System.Data.Entity.SqlServer;
 
 namespace Orleans.StorageProviders.SimpleSQLServerStorage
 {
-    internal class KeyValueDbConfiguration : DbConfiguration
+    public class KeyValueDbConfiguration : DbConfiguration
     {
-        public KeyValueDbConfiguration(): base()
+        public KeyValueDbConfiguration()
         {
-            SetProviderServices(
+            this.SetProviderServices(
                 SqlProviderServices.ProviderInvariantName,            
                 SqlProviderServices.Instance);
 
-            SetDefaultConnectionFactory(new System.Data.Entity.Infrastructure.SqlConnectionFactory());
+            this.SetExecutionStrategy(SqlProviderServices.ProviderInvariantName, () => new SqlAzureExecutionStrategy(2, TimeSpan.FromMilliseconds(100)));
+
+            this.SetDefaultConnectionFactory(new SqlConnectionFactory());
         }
     }
 }

--- a/Orleans.StorageProviders.SimpleSQLServerStorage/KeyValueDbContext.cs
+++ b/Orleans.StorageProviders.SimpleSQLServerStorage/KeyValueDbContext.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Data.Common;
 using System.Data.Entity;
 using System.Linq;
 using System.Text;
@@ -10,8 +11,19 @@ namespace Orleans.StorageProviders.SimpleSQLServerStorage
     [DbConfigurationType(typeof(KeyValueDbConfiguration))]
     class KeyValueDbContext : DbContext
     {
-        public KeyValueDbContext(string connString) : base(connString)
+        /// <summary>
+        /// Constructs a new context instance using the existing connection to connect to a database.
+        /// The connection will not be disposed when the context is disposed if <paramref name="contextOwnsConnection" />
+        /// is <c>false</c>.
+        /// </summary>
+        /// <param name="existingConnection"> An existing connection to use for the new context. </param>
+        /// <param name="contextOwnsConnection">
+        /// If set to <c>true</c> the connection is disposed when the context is disposed, otherwise the caller must dispose the connection.
+        /// </param>
+        public KeyValueDbContext(DbConnection existingConnection, bool contextOwnsConnection) 
+            : base(existingConnection, contextOwnsConnection)
         { }
+
 
         public DbSet<KeyValueStore> KeyValues { get; set; }
     }

--- a/Orleans.StorageProviders.SimpleSQLServerStorage/KeyValueStore.cs
+++ b/Orleans.StorageProviders.SimpleSQLServerStorage/KeyValueStore.cs
@@ -12,10 +12,13 @@ namespace Orleans.StorageProviders.SimpleSQLServerStorage
         [Key]
         [MaxLength(1024)]
         public string GrainKeyId { get; set; }
+
         [MaxLength]
         public byte[] BinaryContent { get; set; }
+
         [MaxLength]
         public string JsonContext { get; set; }
+
 		[MaxLength(100)]
 		public string ETag { get; set; }
 

--- a/Orleans.StorageProviders.SimpleSQLServerStorage/Orleans.StorageProviders.SimpleSQLServerStorage.nuspec
+++ b/Orleans.StorageProviders.SimpleSQLServerStorage/Orleans.StorageProviders.SimpleSQLServerStorage.nuspec
@@ -8,7 +8,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>A KV SQL Server implementation of the Orleans Storage Provider model</description>
     <licenseUrl>http://choosealicense.com/licenses/mit/</licenseUrl>
-    <copyright>Copyright 2016</copyright>
+    <copyright>Copyright 2017</copyright>
     <summary>A KV SQL Server implementation of the Orleans Storage Provider model.</summary>
     <projectUrl>https://github.com/OrleansContrib/Orleans.StorageProviders.SimpleSQLServerStorage</projectUrl>
     <tags>Orleans, sqlserver, storageprovider</tags>

--- a/Orleans.StorageProviders.SimpleSQLServerStorage/SimpleSQLServerProviderErrorCodes.cs
+++ b/Orleans.StorageProviders.SimpleSQLServerStorage/SimpleSQLServerProviderErrorCodes.cs
@@ -22,6 +22,6 @@ namespace Orleans.StorageProviders.SimpleSQLServerStorage
         SimpleSQLServerProvider_InitProvider             = SimpleSQLServerProviderBase + 9,
         SimpleSQLServerProvider_ParamConnectionString    = SimpleSQLServerProviderBase + 10,
         SimpleSQLServerProvider_ReadError                = SimpleSQLServerProviderBase + 11,
-        SimpleSQLServerStorageProvider_ClearingData = 400111,
+        SimpleSQLServerProvider_ClearingData             = SimpleSQLServerProviderBase + 12,
     }
 }

--- a/TestHost/App.config
+++ b/TestHost/App.config
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+    </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/TestHost/OrleansHostWrapper.cs
+++ b/TestHost/OrleansHostWrapper.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Orleans.Runtime;
+using Orleans.Runtime.Configuration;
+using Orleans.Runtime.Host;
+using Orleans.StorageProviders.SimpleSQLServerStorage;
+
+namespace TestHost
+{
+
+    internal class OrleansHostWrapper : IDisposable
+    {
+        public bool Debug
+        {
+            get { return siloHost != null && siloHost.Debug; }
+            set { siloHost.Debug = value; }
+        }
+
+        private SiloHost siloHost;
+
+        /// <summary>
+        /// start primary
+        /// </summary>
+        public OrleansHostWrapper()
+        {
+            var clusterConfig = ClusterConfiguration.LocalhostPrimarySilo();
+
+            var ssBuilder = new SqlConnectionStringBuilder();
+            ssBuilder.DataSource = "localhost";
+            ssBuilder.InitialCatalog = "somedatabase";
+
+            clusterConfig.AddSimpleSQLStorageProvider("basic",
+                ssBuilder.ToString(), @"true");
+
+
+            siloHost = new SiloHost("primary", clusterConfig);
+        }
+
+
+
+        public bool Run()
+        {
+            var ok = false;
+
+            try
+            {
+                siloHost.InitializeOrleansSilo();
+
+                ok = siloHost.StartOrleansSilo();
+                if (!ok)
+                    throw new SystemException(string.Format("Failed to start Orleans silo '{0}' as a {1} node.",
+                        siloHost.Name, siloHost.Type));
+            }
+            catch (Exception exc)
+            {
+                siloHost.ReportStartupError(exc);
+                var msg = string.Format("{0}:\n{1}\n{2}", exc.GetType().FullName, exc.Message, exc.StackTrace);
+                Console.WriteLine(msg);
+            }
+
+            return ok;
+        }
+
+        public bool Stop()
+        {
+            var ok = false;
+
+            try
+            {
+                siloHost.StopOrleansSilo();
+            }
+            catch (Exception exc)
+            {
+                siloHost.ReportStartupError(exc);
+                var msg = $"{exc.GetType().FullName}:\n{exc.Message}\n{exc.StackTrace}";
+                Console.WriteLine(msg);
+            }
+
+            return ok;
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+
+        protected virtual void Dispose(bool dispose)
+        {
+            siloHost.Dispose();
+            siloHost = null;
+        }
+    }
+}

--- a/TestHost/Program.cs
+++ b/TestHost/Program.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TestHost
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            // The Orleans silo environment is initialized in its own app domain in order to more
+            // closely emulate the distributed situation, when the client and the server cannot
+            // pass data via shared memory.
+            AppDomain hostDomain = AppDomain.CreateDomain("OrleansHost", null, new AppDomainSetup
+            {
+                AppDomainInitializer = InitSilo,
+                AppDomainInitializerArguments = args,
+            });
+
+
+            Console.WriteLine("Orleans Silo is running.\nPress Enter to terminate...");
+            Console.ReadLine();
+
+            hostDomain.DoCallBack(ShutdownSilo);
+        }
+        static void InitSilo(string[] args)
+        {
+            hostWrapper = new OrleansHostWrapper();
+
+            if (!hostWrapper.Run())
+            {
+                Console.Error.WriteLine("Failed to initialize Orleans silo");
+            }
+        }
+
+        static void ShutdownSilo()
+        {
+            if (hostWrapper != null)
+            {
+                hostWrapper.Dispose();
+                GC.SuppressFinalize(hostWrapper);
+            }
+        }
+
+        private static OrleansHostWrapper hostWrapper;
+    }
+}

--- a/TestHost/Properties/AssemblyInfo.cs
+++ b/TestHost/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("TestHost")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("TestHost")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("34cfddfc-d674-479b-9046-3e3776f15bb1")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/TestHost/TestHost.csproj
+++ b/TestHost/TestHost.csproj
@@ -1,0 +1,100 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{34CFDDFC-D674-479B-9046-3E3776F15BB1}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>TestHost</RootNamespace>
+    <AssemblyName>TestHost</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.1.0.0\lib\netstandard1.1\Microsoft.Extensions.DependencyInjection.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.0.0\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Orleans, Version=1.3.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Orleans.Core.1.3.0\lib\net451\Orleans.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="OrleansRuntime, Version=1.3.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Orleans.OrleansRuntime.1.3.0\lib\net451\OrleansRuntime.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Collections.Immutable, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.1.2.0\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="OrleansHostWrapper.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Orleans.StorageProviders.SimpleSQLServerStorage\Orleans.StorageProviders.SimpleSQLServerStorage.csproj">
+      <Project>{EC70A034-22ED-4CF8-AB4B-7F89E5395268}</Project>
+      <Name>Orleans.StorageProviders.SimpleSQLServerStorage</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\tests\SimpleGrainInterfaces\SimpleGrainInterfaces.csproj">
+      <Project>{3ff17408-e556-43f5-af82-5881dc1551a0}</Project>
+      <Name>SimpleGrainInterfaces</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Tests\SimpleGrains\SimpleGrains.csproj">
+      <Project>{563672ab-ea40-49d8-bebc-e0152d98615e}</Project>
+      <Name>SimpleGrains</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/TestHost/packages.config
+++ b/TestHost/packages.config
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Extensions.DependencyInjection" version="1.0.0" targetFramework="net452" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.0.0" targetFramework="net452" />
+  <package id="Microsoft.Orleans.Core" version="1.3.0" targetFramework="net452" />
+  <package id="Microsoft.Orleans.OrleansRuntime" version="1.3.0" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
+  <package id="System.Collections" version="4.0.11" targetFramework="net452" />
+  <package id="System.Collections.Concurrent" version="4.0.12" targetFramework="net452" />
+  <package id="System.Collections.Immutable" version="1.2.0" targetFramework="net452" />
+  <package id="System.ComponentModel" version="4.0.1" targetFramework="net452" />
+  <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net452" />
+  <package id="System.Globalization" version="4.0.11" targetFramework="net452" />
+  <package id="System.Linq" version="4.1.0" targetFramework="net452" />
+  <package id="System.Linq.Expressions" version="4.1.0" targetFramework="net452" />
+  <package id="System.Reflection" version="4.1.0" targetFramework="net452" />
+  <package id="System.Resources.ResourceManager" version="4.0.1" targetFramework="net452" />
+  <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="net452" />
+  <package id="System.Threading" version="4.0.11" targetFramework="net452" />
+  <package id="System.Threading.Tasks" version="4.0.11" targetFramework="net452" />
+</packages>


### PR DESCRIPTION
#15 Changing the `DbContext` constructor from using a string (too many config possibilities) to using a `DbConnection`.  This allowed the `DbConfigurationTypeAttribute` to be properly loaded.